### PR TITLE
#31 POST lens data instead of nfc_tag data.

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -193,7 +193,7 @@ class TapManager:
   def send_tap(self, id):
     """refer to docs.python-requests.org for implementation examples"""
     params={
-      'nfc_tag': {
+      'lens': {
         'uid':id
       },
       'tap_datetime': datetime.now(TZ).isoformat(),


### PR DESCRIPTION
*Resolves issue #29*

Update tap post data to send lens information.

### Acceptance Criteria
- [x] Update JSON to include `lens` data instead of `nfc_tag` data

### Relevant design files
* None

### Testing instructions
1. Set a tap reader to point `TARGET_API_ENDPOINT` to `http://<your-computer-ip>:8000/api/` https://dashboard.balena-cloud.com/devices/134aedbcf90f8c89a756eb208c551c23/envvars
1. See that the tap is successfully posted to XOS: https://localhost:8000/django-admin/exhibitions/tap/

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
