### PR TITLE
#39 Pin Adafruit Platform Detect package

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,3 +6,6 @@ sentry-sdk
 RPi.GPIO
 git+https://github.com/ACMILabs/Adafruit_Blinka.git
 adafruit-circuitpython-dotstar
+
+# Pin platform detect to avoid issue #39
+Adafruit-PlatformDetect==1.3.4


### PR DESCRIPTION
*Resolves issue #39*

Pin Adafruit Platform Detect package to avoid exception.

### Acceptance Criteria
- [x] Pin Adafruit library `Adafruit-PlatformDetect==1.3.4` to avoid these errors

### Relevant design files
* None

### Testing instructions
1. Push this to the experimental lens reader app `balena push e__tap-reader-pi-4`
1. See that taps and the LEDs function in one of the readers: https://dashboard.balena-cloud.com/apps/1509309/devices

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- ~[ ] New logic has been documented~
- ~[ ] New logic has appropriate unit tests~
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
