### PR TITLE
#43 Queue taps if network disruption

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -14,8 +14,6 @@ from time import sleep, time
 import requests
 import sentry_sdk
 from flask import Flask, request
-from requests.exceptions import ConnectionError as RequestsConnectionError
-from requests.exceptions import Timeout
 
 from src.utils import IP_ADDRESS, IS_OSX, MAC_ADDRESS, TZ, env_to_tuple, log
 
@@ -291,7 +289,10 @@ class TapManager:
             sentry_sdk.capture_message(response.text)
             return 1
 
-        except (RequestsConnectionError, Timeout) as connection_error:
+        except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout
+        ) as connection_error:
             log('Failed to post tap message to %s: %s\n%s' % (
                 TARGET_TAPS_ENDPOINT, tap, str(connection_error)
             ))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,7 @@
 from time import sleep, time
 from unittest.mock import MagicMock, patch
 
-from requests.exceptions import ConnectionError as RequestsConnectionError
+import requests
 
 import src.runner
 from src.runner import LEDControllerThread, TapManager
@@ -101,7 +101,7 @@ def test_send_tap_or_requeue(xos_request):
     assert tap_manager.queue.empty()
 
 
-@patch('requests.post', MagicMock(side_effect=RequestsConnectionError()))
+@patch('requests.post', MagicMock(side_effect=requests.exceptions.ConnectionError()))
 def test_send_tap_or_requeue_no_network():
     """
     Test send_tap_or_requeue enqueues tap again on network failure
@@ -123,7 +123,7 @@ def test_send_tap_or_requeue_no_network():
     assert tap['lens']['uid'] == '123456789'
 
 
-@patch('requests.post', MagicMock(side_effect=RequestsConnectionError()))
+@patch('requests.post', MagicMock(side_effect=requests.exceptions.ConnectionError()))
 @patch('sentry_sdk.capture_exception', side_effect=MagicMock())
 def test_send_tap_or_requeue_no_network_does_not_spam_sentry(capture_exception):
     """


### PR DESCRIPTION
Resolves #43

- On `tap_on`, put taps in a queue
- On a separate thread, try to send taps constantly. If XOS is unreachable, wait `TAP_SEND_RETRY_SECS` (default 5) seconds before trying again

### Acceptance Criteria
- [X] Tap reader should queue taps and return success even if no network/server is available
- [X] When network is reconnected to tap reader, taps are sent, with original timestamps

### Relevant design files
* None

### Testing instructions
1. Deploy this branch to a lens reader or move a lens reader to application [e__tap-reader-pi-4](https://dashboard.balena-cloud.com/apps/1509309/devices)
2. Once the tap reader has started, make some taps and ensure they are being received by XOS (maybe your local instance by setting `TARGET_API_ENDPOINT` with your IP)
3. Disconnect the network from the lens reader and make some taps. Make sure the LEDs indicate success.
4. Reconnect the network and check that the taps are now sent to XOS.

### DoD
For requester to complete:
- [X] All acceptance criteria are met
- [X] New logic has been documented
- [X] New logic has appropriate unit tests
~Changelog has been updated if necessary~
~Deployment / migration instruction have been updated if required~
