### PR TITLE
#41 Add device_name and ip_address from Balena supervisor API

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,7 @@ extension-pkg-whitelist=alsaaudio
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS, migrations, settings, venv, Makefile, Dockerfile, Dockerfile.template, Dockerfile.raspberrypi4-64, requirements, resources, setupJest.js, package.json, package-lock.json, node_modules, scripts, .git, __pycache__, npm-debug.log, adafruit_dotstar.py
+ignore=CVS, migrations, settings, venv, Makefile, Dockerfile, Dockerfile.template, Dockerfile.raspberrypi4-64, requirements, resources, setupJest.js, package.json, package-lock.json, node_modules, scripts, .git, __pycache__, npm-debug.log, adafruit_dotstar.py, LICENSE
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,7 +1,7 @@
 -r base.txt
 
 flake8
-isort
+isort>=4.2.5,<5
 pylint
 pytest
 pytest-flask

--- a/src/runner.py
+++ b/src/runner.py
@@ -36,9 +36,8 @@ AUTH_TOKEN = os.getenv('AUTH_TOKEN', '')
 XOS_LABEL_ID = os.getenv('XOS_LABEL_ID', '1')
 SENTRY_ID = os.getenv('SENTRY_ID')
 
-DEVICE_NAME = os.getenv('DEVICE_NAME')
+DEVICE_NAME = os.getenv('BALENA_DEVICE_NAME_AT_INIT')
 READER_MODEL = os.getenv('READER_MODEL')
-READER_NAME = DEVICE_NAME or 'nfc-' + IP_ADDRESS.split('.')[-1]  # not user-settable
 
 TAP_OFF_TIMEOUT = float(os.getenv('TAP_OFF_TIMEOUT', '0.5'))  # seconds
 LEDS_BRIGHTNESS = float(os.getenv('LEDS_BRIGHTNESS', '1.0'))
@@ -258,10 +257,10 @@ class TapManager:
             'label': XOS_LABEL_ID,
             'data': {
                 'lens_reader': {
+                    'device_name': DEVICE_NAME,
                     'mac_address': MAC_ADDRESS,
                     'reader_ip': IP_ADDRESS,
                     'reader_model': READER_MODEL,
-                    'reader_name': READER_NAME,
                 }
             }
         }

--- a/src/runner.py
+++ b/src/runner.py
@@ -36,8 +36,8 @@ AUTH_TOKEN = os.getenv('AUTH_TOKEN', '')
 XOS_LABEL_ID = os.getenv('XOS_LABEL_ID', '1')
 SENTRY_ID = os.getenv('SENTRY_ID')
 
-DEVICE_NAME = os.getenv('BALENA_DEVICE_NAME_AT_INIT')
-READER_MODEL = os.getenv('READER_MODEL')
+DEVICE_NAME = os.getenv('BALENA_DEVICE_NAME_AT_INIT', 'DD-00')
+READER_MODEL = os.getenv('READER_MODEL', 'IDTech Kiosk IV')
 
 TAP_OFF_TIMEOUT = float(os.getenv('TAP_OFF_TIMEOUT', '0.5'))  # seconds
 LEDS_BRIGHTNESS = float(os.getenv('LEDS_BRIGHTNESS', '1.0'))

--- a/tests/data/device.json
+++ b/tests/data/device.json
@@ -1,0 +1,12 @@
+{
+  "api_port": 48484,
+  "ip_address": "10.1.2.3",
+  "os_version": "balenaOS 2.47.0+rev1",
+  "supervisor_version": "10.6.27",
+  "update_pending": false,
+  "update_failed": false,
+  "update_downloaded": false,
+  "commit": "c468f03fb6608929cd8cc775381ae4f7",
+  "status": "Idle",
+  "download_progress": null
+}


### PR DESCRIPTION
Resolves #41, ACMILabs/xos#2230

Lens reader posts device_name and its correct IP address for Constellations table app.

### Acceptance Criteria
- [x] When a tap reader is in a multi-container environment it returns its correct IP address
- [x] Add `device_name` to the Lens tap `data` dictionary ACMILabs/xos#2230

### Relevant design files
* None

### Testing instructions
1. Make sure tests and linting passes: `cd development` and `docker-compose up --build` and `docker exec -it lensreader make linttest`
1. Check that this runs on a real device: [s__tap-reader-pi-4](https://dashboard.balena-cloud.com/apps/1520826/devices)
1. Check that the Tap `data` includes the device's `ip_address` and `device_name`: https://xos.acmi.net.au/admin/exhibitions/tap/

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
- ~[ ] Deployment / migration instruction have been updated if required~
