### PR TITLE
#50 Fix LED API to prevent Taps being sent to XOS when the LEDs are toggled

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ To turn the lights on, set the `cross_fade` value to a float greater than 0, up 
 
 To turn the lights off, set the `cross_fade` value to 0.
 
+**Note**: When the `cross_fade` value is greater than `0`, Taps are not sent to XOS.
+
 ### Headers
 ```
 Content-Type: application/json
@@ -139,7 +141,7 @@ Content-Type: application/json
 
 ### Example
 
-Override the colour of the LEDs, and set them to a specific colour:
+Override the colour of the LEDs, and set them to a specific colour (which also prevents Taps being sent to XOS):
 
 ```
 curl -X POST -H "Content-Type: application/json" -d '{

--- a/src/runner.py
+++ b/src/runner.py
@@ -316,16 +316,22 @@ class TapManager:
         if not self.leds.blocked_by:
             self.leds.blocked_by = 'tap'
             self.leds.success_on()
-        tap = self.create_tap(self.last_id)
-        self.queue.put((tap['tap_datetime'], tap))
+            tap = self.create_tap(self.last_id)
+            self.queue.put((tap['tap_datetime'], tap))
+        else:
+            log('Tap blocked by: ', self.leds.blocked_by)
 
     def tap_off(self):
         log("Tap Off: ", self.last_id)
-        # turn leds off only if triggered by a tap
         if self.leds.blocked_by == 'tap':
+            # if blocked by a tap, turn LEDs off
             self.last_id = None
             self.leds.success_off()
             self.leds.blocked_by = None
+        elif self.leds.blocked_by == 'remote':
+            # if blocked by a remote LEDs command, leave LEDs alone, and only reset
+            # last lens id so we can still receive new tap on events
+            self.last_id = None
 
     def _reset_tap_off_timer(self):
         # reset the tap-off timer for this ID
@@ -403,7 +409,15 @@ def toggle_lights():
         assert (tap_manager.leds.blocked_by == 'remote' and cross_fade == 0.0) or \
             (not tap_manager.leds.blocked_by and cross_fade > 0.0)
 
-        tap_manager.leds.blocked_by = 'remote' if cross_fade > 0.0 else None
+        if cross_fade > 0.0:
+            # block taps and LED events
+            tap_manager.leds.blocked_by = 'remote'
+        else:
+            # reset ready for more taps
+            tap_manager.last_id = None
+            tap_manager.leds.success_off()
+            tap_manager.leds.blocked_by = None
+
         tap_manager.leds.toggle_lights(rgb_value, ramp_time, cross_fade)
         return 'Leds toggled successfully.', 200
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -132,6 +132,7 @@ def test_send_tap_or_requeue(xos_request):
     # add two taps to the queue
     tap_manager.last_id = '123456789'
     tap_manager.tap_on()
+    tap_manager.tap_off()
     tap_manager.last_id = '000000000'
     tap_manager.tap_on()
     assert tap_manager.queue.qsize() == 2


### PR DESCRIPTION
Resolves #50

Fix LED API to prevent Taps being sent to XOS when the LEDs are toggled on, and allow Taps to be sent when the LEDs are toggled back to their normal state.

### Acceptance Criteria
- [x] When LEDs are set to a specific colour, posting taps should be prevented
- [x] When LEDs are set back to their default breathing animation, taps should be sent to XOS

### Relevant design files
* None

### Testing instructions
1. Check that the tests pass: `cd development` and `docker-compose up --build` and then in another tab `docker exec -it lensreader make linttest`
1. Add your test lens reader to: https://dashboard.balena-cloud.com/apps/1509309
1. Tap to make sure the lens reader is working, see your taps: https://xos.acmi.net.au/my-visit/
1. Then toggle the LEDs on and see that Taps aren't sent to XOS
1. Toggle the LEDs off again and see that Taps resume being sent to XOS

POST this to a Lens Reader to turn off the LEDs:

```bash
curl --location --request POST 'http://10.1.1.1:8082/api/lights/' \
--header 'Content-Type: application/json' \
--data-raw '{
    "rgb_value": [5,25,25],
    "ramp_time": 0.5,
    "cross_fade": 1.0
}'
```

Then POST this to a Lens Reader to turn on the LEDs:

```bash
curl --location --request POST 'http://10.1.1.1:8082/api/lights/' \
--header 'Content-Type: application/json' \
--data-raw '{
    "rgb_value": [5,25,25],
    "ramp_time": 0.5,
    "cross_fade": 0.0
}'
```

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [ ] New logic has been documented
- [ ] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
- [ ] Deployment / migration instruction have been updated if required
