### PR TITLE
#53 Handle 400 response for a lens uid that doesn't exist in XOS

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -141,7 +141,8 @@ disable=print-statement,
         comprehension-escape,
         # ACMI entries
         missing-docstring,
-        no-self-use
+        no-self-use,
+        too-few-public-methods
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/runner.py
+++ b/src/runner.py
@@ -279,7 +279,7 @@ class TapManager:
                 log(response.text)
                 return 0
 
-            if response.status_code == 404:
+            if response.status_code in [400, 404]:  # 400 UID doesn't exist in XOS
                 log(response.text)
                 self.leds.failed()
                 return 1

--- a/src/runner.py
+++ b/src/runner.py
@@ -53,6 +53,8 @@ LEDS_IN_STRING = int(os.getenv('LEDS_IN_STRING', '12'))  # Number of LEDs to lig
 
 TAP_SEND_RETRY_SECS = int(os.getenv('TAP_SEND_RETRY_SECS', '5'))
 
+XOS_FAILED_RESPONSE_CODES = [400, 404]  # 400 Lens UID not found in XOS
+
 if IS_OSX:
     FOLDER = './bin/mac/'
 else:
@@ -240,6 +242,7 @@ class TapManager:
         # Tap init
         self.last_id = None
         self.last_id_time = time()
+        self.last_id_failed = False
         self.tap_off_timer = None
         self.leds = LEDControllerThread()
         self.queue = PriorityQueue()
@@ -279,9 +282,16 @@ class TapManager:
                 log(response.text)
                 return 0
 
-            if response.status_code in [400, 404]:  # 400 UID doesn't exist in XOS
+            if response.status_code in XOS_FAILED_RESPONSE_CODES:
                 log(response.text)
-                self.leds.failed()
+                self.last_id_failed = True
+                if not self.leds.blocked_by:
+                    # XOS returned a failed tap after the visitor tapped off,
+                    # so show the failed LED state asynchronously.
+                    # Possible UX problem: the visitor walks away before the LEDs
+                    # show the failed state.
+                    self.leds.failed()
+                    self.last_id_failed = False
                 return 1
 
             log(response.text)
@@ -323,8 +333,13 @@ class TapManager:
         log("Tap Off: ", self.last_id)
         # turn leds off only if triggered by a tap
         if self.leds.blocked_by == 'tap':
-            self.last_id = None
             self.leds.success_off()
+            if self.last_id_failed:
+                # XOS has returned a failed tap before the visitor tapped off,
+                # so show the failed LED state now.
+                self.leds.failed()
+            self.last_id = None
+            self.last_id_failed = False
             self.leds.blocked_by = None
 
     def _reset_tap_off_timer(self):


### PR DESCRIPTION
Resolves #53

Add `400` response for a Lens UID that doesn't exist in XOS so that the Lens Reader flashes the failed response.

### Acceptance Criteria
- [x] Add `400` response to the error responses handled by the lens reader

### Relevant design files
* None

### Testing instructions
1. Add your Lens Reader to the [s__tap-reader-pi-4](https://dashboard.balena-cloud.com/apps/1520826/devices) application.
1. Tap your myki and see that an error colour flashes
1. Start your development environment: `cd development` and `docker-compose up`
1. Run tests: `docker exec -it lensreader make linttest`

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
