### PR TITLE
#55 Add LED control override for maker moments so they can override the lens tap LED response

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ LEDS_BREATHE_COLOUR_IN=95,70,26     # RGB Medium warm white
 LEDS_SUCCESS_COLOUR=255,238,202     # RGB Bright warm white
 LEDS_FAILED_COLOUR=137,0,34         # RGB Medium red
 LEDS_SIGNAL_TIMES=0.3,0.5,0.6       # Seconds to take for success/failed colour fade in, auto-hold (if needed), fade out.
+LEDS_CONTROL_OVERRIDE=false         # set to 'true' to override lens tap LED responses with LED API control commands
 ```
 
 # Tap API calls
@@ -80,6 +81,8 @@ Each maker moment will provide its own `TARGET_API_ENDPOINT` URL to receive tap 
 
 * `maker_moment` is a constant integer which determines the maker moment that was tapped. XOS team can advise this value for each maker moment.
 * `experience_id` is a unique string that identifies the experience which was just saved. The ID can be used at retrieval time to e.g. locate specific media and metadata on cloud storage. In other words, all media and metadata should be identifiable from constants and the `experience_id`.
+
+The default LED behaviour is never to interrupt a lens tap, but should a maker moment need to override the LED control while a lens is still on the lens reader, `LEDS_CONTROL_OVERRIDE` must be set `true`.
 
 # Compiling the `idtech` application (in C)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -351,6 +351,7 @@ def test_toggle_lights():
     Test the toggle_lights route.
     """
     tap_manager = src.runner.tap_manager
+    tap_manager.__init__()
     with src.runner.app.test_client() as client:
         assert not tap_manager.leds.blocked_by
 
@@ -396,3 +397,88 @@ def test_toggle_lights():
         tap_manager.tap_on()
         tap_manager.tap_off()
         assert tap_manager.queue.qsize() == 1
+
+
+def test_toggle_lights_without_leds_control_override():
+    """
+    Test that the toggle_lights route responds as expected when
+    the LEDS_CONTROL_OVERRIDE flag isn't set.
+    """
+    tap_manager = src.runner.tap_manager
+    tap_manager.__init__()
+    with src.runner.app.test_client() as client:
+        assert not tap_manager.leds.blocked_by
+
+        # tap on, but not off
+        tap_manager.last_id = '123456789'
+        tap_manager.tap_on()
+        assert tap_manager.queue.qsize() == 1
+
+        # turn on LEDs
+        data = dict(
+            rgb_value=[5, 25, 25],
+            ramp_time=0.5,
+            cross_fade=1.0,
+        )
+        response = client.post(
+            '/api/lights/',
+            data=json.dumps(data),
+            content_type='application/json',
+        )
+        assert response.status_code == 409
+        assert tap_manager.leds.blocked_by == 'tap'
+        assert tap_manager.leds.ramp_target_colour != data['rgb_value']
+
+
+def test_toggle_lights_with_leds_control_override():
+    """
+    Test that the toggle_lights route responds as expected when
+    the LEDS_CONTROL_OVERRIDE flag is set True.
+    """
+    src.runner.LEDS_CONTROL_OVERRIDE = True
+    tap_manager = src.runner.tap_manager
+    tap_manager.__init__()
+    with src.runner.app.test_client() as client:
+        assert not tap_manager.leds.blocked_by
+
+        # tap on, but not off
+        tap_manager.last_id = '123456789'
+        tap_manager.tap_on()
+        assert tap_manager.queue.qsize() == 1
+
+        # turn on LEDs
+        data = dict(
+            rgb_value=[5, 25, 25],
+            ramp_time=0.5,
+            cross_fade=1.0,
+        )
+        response = client.post(
+            '/api/lights/',
+            data=json.dumps(data),
+            content_type='application/json',
+        )
+        assert response.status_code == 200
+        assert tap_manager.leds.blocked_by == 'remote'
+        assert tap_manager.leds.ramp_target_colour == data['rgb_value']
+        assert tap_manager.leds.ramp_target == data['cross_fade']
+        assert tap_manager.leds.ramp_duration == data['ramp_time']
+
+        # turn off LEDs
+        data = dict(
+            rgb_value=[5, 25, 25],
+            ramp_time=0.5,
+            cross_fade=0.0,
+        )
+        response = client.post(
+            '/api/lights/',
+            data=json.dumps(data),
+            content_type='application/json',
+        )
+        assert response.status_code == 200
+        assert not tap_manager.leds.blocked_by
+
+        # try and tap
+        tap_manager.last_id = '123456789'
+        tap_manager.tap_on()
+        tap_manager.tap_off()
+        assert tap_manager.queue.qsize() == 2


### PR DESCRIPTION
Resolves #55

Add LED control override ability so that a maker moment can override a lens tap led response with its own LED API request.

### Acceptance Criteria
- [x] LED control accepts a `POST` command when a Lens is on the reader if `LEDS_CONTROL_OVERRIDE` is set `true`

### Relevant design files
* None

### Testing instructions
1. Add your lens reader to [s__tap-reader-pi-4](https://dashboard.balena-cloud.com/apps/1520826/devices)
1. Place your lens on the lens reader, then try to send an LED API POST request and see that it fails with a `409`
1. Add the environment variable: `LEDS_CONTROL_OVERRIDE=true`
1. Repeat the above steps and note that it succeeds in setting the LEDS and returns a `200`

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- ~[ ] Changelog has been updated if necessary~
- ~[ ] Deployment / migration instruction have been updated if required~
