### PR TITLE
#58 Add a POST request to the building's onboarding lights for an onboarding tap

### DIFF
--- a/tests/tests.py
+++ b/tests/tests.py
@@ -482,3 +482,48 @@ def test_toggle_lights_with_leds_control_override():
         tap_manager.tap_on()
         tap_manager.tap_off()
         assert tap_manager.queue.qsize() == 2
+
+
+@patch('requests.post', side_effect=MagicMock())
+def test_success_on_onboarding_lights(led_post):
+    """
+    Test that the onboarding lights POST request is sent as expected,
+    and errors are handled successfully.
+    """
+    leds_controller = LEDControllerThread()
+    leds_controller.success_on_onboarding_lights()
+    assert led_post.call_count == 0
+
+    src.runner.ONBOARDING_LEDS_API = 'https://xos.acmi.net.au/api/fake'
+    src.runner.ONBOARDING_LEDS_DATA = '{}'
+    leds_controller.success_on_onboarding_lights()
+    assert led_post.call_count == 1
+
+
+@patch('requests.post', MagicMock(side_effect=[
+    requests.exceptions.ConnectionError(),
+    requests.exceptions.Timeout(),
+    requests.exceptions.HTTPError(),
+]))
+@patch('sentry_sdk.capture_exception', side_effect=MagicMock())
+def test_success_on_onboarding_lights_fails_gracefully(capture_exception):
+    """
+    Test that the onboarding lights POST request is sent as expected,
+    and errors are handled successfully.
+    """
+    src.runner.ONBOARDING_LEDS_API = None
+    leds_controller = LEDControllerThread()
+    leds_controller.success_on_onboarding_lights()
+    assert capture_exception.call_count == 0
+
+    src.runner.ONBOARDING_LEDS_API = 'https://xos.acmi.net.au/api/fake'
+    src.runner.ONBOARDING_LEDS_DATA = 'not-json'
+    leds_controller.success_on_onboarding_lights()
+    assert capture_exception.call_count == 1
+    src.runner.ONBOARDING_LEDS_DATA = '{"this": "that"}'
+    leds_controller.success_on_onboarding_lights()
+    assert capture_exception.call_count == 2
+    leds_controller.success_on_onboarding_lights()
+    assert capture_exception.call_count == 3
+    leds_controller.success_on_onboarding_lights()
+    assert capture_exception.call_count == 4


### PR DESCRIPTION
Resolves #58

As a new visitor to ACMI I would like to see the onboarding lights to react when I tap my Lens.

### Acceptance Criteria
- [x] Send a POST request to `ONBOARDING_LEDS_API` with data `ONBOARDING_LEDS_DATA`

### Relevant design files
* None

### Testing instructions
1. Setup an `e__tap-reader-pi-4` lens reader running from a battery and wifi to the onboarding station
2. Set the environment variable `ONBOARDING_LEDS_API` to `http://<YOUR_IP_ADDRESS>:5000/api/trigger/`
3. Set the environment variable `ONBOARDING_LEDS_DATA` to `{"TODO": "TODO"}`
3. Start up a Flask server with the code below by running `export FLASK_APP=server.py` and `flask run --host=0.0.0.0`
4. Tap your lens reader, and see the onboarding LED lights debug message appears, and a `POST` requests in your flask server appears.
5. Run the tests with `cd development` and `docker-compose up` and `docker exec -it lensreader pytest -s -v`

```python
# server.py
from flask import Flask
app = Flask(__name__)

@app.route('/')
def home():
    return trigger()

@app.route('/api/trigger/', methods=['GET', 'POST'])
def trigger():
    return {"ok": True}
```

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
