### PR TITLE
#62 Handle 200 response codes from Maker Moments

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -56,6 +56,7 @@ LEDS_CONTROL_OVERRIDE = os.getenv('LEDS_CONTROL_OVERRIDE', 'false').lower() == '
 TAP_SEND_RETRY_SECS = int(os.getenv('TAP_SEND_RETRY_SECS', '5'))
 
 XOS_FAILED_RESPONSE_CODES = [400, 404]  # 400 Lens UID not found in XOS
+TAP_SUCCESS_RESPONSE_CODES = [200, 201]  # 200 Maker Moments, 201 XOS
 
 ONBOARDING_LEDS_API = os.getenv('ONBOARDING_LEDS_API')
 ONBOARDING_LEDS_DATA = os.getenv('ONBOARDING_LEDS_DATA')
@@ -257,8 +258,8 @@ class LEDControllerThread(Thread):
                 ))
                 sentry_sdk.capture_exception(exception)
             except (
-                requests.exceptions.ConnectionError,
-                requests.exceptions.Timeout
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.Timeout
             ) as connection_error:
                 log('Failed to post onboarding lights to %s: %s\n%s' % (
                     ONBOARDING_LEDS_API,
@@ -324,7 +325,7 @@ class TapManager:
         try:
             response = requests.post(url=TARGET_TAPS_ENDPOINT, json=tap, headers=headers, timeout=5)
             self.post_to_sentry = True
-            if response.status_code == 201:
+            if response.status_code in TAP_SUCCESS_RESPONSE_CODES:
                 log(response.text)
                 return 0
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -258,8 +258,8 @@ class LEDControllerThread(Thread):
                 ))
                 sentry_sdk.capture_exception(exception)
             except (
-                    requests.exceptions.ConnectionError,
-                    requests.exceptions.Timeout
+                requests.exceptions.ConnectionError,
+                requests.exceptions.Timeout
             ) as connection_error:
                 log('Failed to post onboarding lights to %s: %s\n%s' % (
                     ONBOARDING_LEDS_API,
@@ -346,8 +346,8 @@ class TapManager:
             return 1
 
         except (
-                requests.exceptions.ConnectionError,
-                requests.exceptions.Timeout
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout
         ) as connection_error:
             log('Failed to post tap message to %s: %s\n%s' % (
                 TARGET_TAPS_ENDPOINT, tap, str(connection_error)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,7 @@
 import json
 import os
 from time import sleep, time
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, PropertyMock
 
 import requests
 
@@ -79,6 +79,11 @@ def mocked_requests_post(*args, **kwargs):
 
         def raise_for_status(self):
             return None
+
+    if 'maker-moment' in kwargs['url']:
+        return MockResponse('{"response": "200"}', 200)
+    elif 'xos' in kwargs['url']:
+        return MockResponse('{"response": "201"}', 201)
 
     return MockResponse('["No lens matching that uid could be found."]', 400)
 
@@ -174,6 +179,35 @@ def test_send_tap_or_requeue(xos_request):
 
     assert xos_request.call_count == 2
     assert tap_manager.queue.empty()
+
+
+@patch('requests.post', MagicMock(side_effect=mocked_requests_post))
+def test_send_tap_or_requeue_success_codes():
+    """
+    Test send_tap_or_requeue handles all response codes in TAP_SUCCESS_RESPONSE_CODES.
+    """
+    tap_manager = TapManager()
+    assert tap_manager.queue.empty()
+
+    # add two taps to the queue
+    tap_manager.last_id = '123456789'
+    tap_manager.tap_on()
+    tap_manager.tap_off()
+    tap_manager.last_id = '000000000'
+    tap_manager.tap_on()
+    assert tap_manager.queue.qsize() == 2
+
+    # send the taps
+    # Mock XOS response
+    src.runner.TARGET_TAPS_ENDPOINT = 'https://xos.acmi.net.au/api/taps/'
+    assert tap_manager.send_tap_or_requeue() == 0
+    # Mock Maker Moment response
+    src.runner.TARGET_TAPS_ENDPOINT = 'https://maker-moment/api/taps/'
+    assert tap_manager.send_tap_or_requeue() == 0
+
+    assert tap_manager.queue.empty()
+    # Reset Taps endpoint
+    src.runner.TARGET_TAPS_ENDPOINT = 'http://localhost:8000/api/taps/'
 
 
 @patch('requests.post', MagicMock(side_effect=mocked_requests_post))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,7 @@
 import json
 import os
 from time import sleep, time
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, patch
 
 import requests
 
@@ -80,12 +80,14 @@ def mocked_requests_post(*args, **kwargs):
         def raise_for_status(self):
             return None
 
-    if 'maker-moment' in kwargs['url']:
-        return MockResponse('{"response": "200"}', 200)
-    elif 'xos' in kwargs['url']:
-        return MockResponse('{"response": "201"}', 201)
+    response = MockResponse('["No lens matching that uid could be found."]', 400)
 
-    return MockResponse('["No lens matching that uid could be found."]', 400)
+    if 'maker-moment' in kwargs['url']:
+        response = MockResponse('{"response": "200"}', 200)
+    elif 'xos' in kwargs['url']:
+        response = MockResponse('{"response": "201"}', 201)
+
+    return response
 
 
 def test_leds_ramp_on():


### PR DESCRIPTION
Resolves #62

Handles `200` success responses from Maker Moments so that their responses aren't logged to Sentry.

### Acceptance Criteria
- [x] Handle `200` responses to Tap posts to Maker Moments so messages aren't sent to Sentry

### Relevant design files
* None

### Testing instructions
1. Run tests: `cd development` and `docker-compose up` and `docker exec -it lensreader make test`
2. Make sure you have an entry for `SENTRY_ID`
2. Run a Flask server, and see that a Tap doesn't post to Sentry

Flask server:

```python
from flask import Flask, request
app = Flask(__name__)

@app.route('/')
def home():
    return trigger()

@app.route('/api/trigger', methods=['GET', 'POST'])
def trigger():
    print(request.get_json())
    return {"ok": True}

@app.route('/api/taps/', methods=['POST'])
def taps():
    print(request.get_json())
    return {"ok": True}
```

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
