### PR TITLE
#64 Update Lens Reader LED responses to flash for 2 seconds

### DIFF
--- a/tests/data/tap.json
+++ b/tests/data/tap.json
@@ -1,0 +1,79 @@
+{
+    "id": 379,
+    "tap_datetime": "2021-04-07T08:43:44.202649+10:00",
+    "created_at": "2021-04-07T09:46:25.245753+10:00",
+    "lens_hash": "c422c99bb835a4864b0165e453cfa3953108771bb5c63b071b17bbfa1d406c48",
+    "lens_short_code": "m12345",
+    "experience_id": null,
+    "maker_moment": null,
+    "collectible": {
+        "id": 1,
+        "acmi_id": "tmdb-tv-62560",
+        "title": "",
+        "thumbnail": {
+            "image_url": "https://xos.acmi.net.au/fake-image.png",
+            "has_video": false
+        },
+        "slug": "mr-robot-label-title",
+        "type": "TV show",
+        "work": {
+            "id": 2,
+            "acmi_id": "tmdb-tv-62560",
+            "title": "Mr. Robot",
+            "title_annotation": "",
+            "slug": "mr-robot",
+            "creator_credit": "Kyle Bradstreet, Sam Esmail, Kor Adana and Randolph Leon",
+            "credit_line": "<p>Vernon credit line</p>",
+            "headline_credit": "US, 2015",
+            "thumbnail": {
+                "image_url": "https://xos.acmi.net.au/fake-image.png",
+                "has_video": false
+            },
+            "record_type": "work",
+            "type": "TV show",
+            "is_on_display": false,
+            "last_on_display_place": null,
+            "last_on_display_date": null,
+            "is_context_indigenous": false,
+            "material_description": "",
+            "unpublished": false,
+            "first_production_date": "2015-05-27T10:00:00+10:00",
+            "brief_description": "<p>Description for constellation</p>",
+            "constellations_primary": [
+                {
+                    "id": 1,
+                    "name": "The robot",
+                    "description": "From <b>Simon</b>."
+                }
+            ],
+            "constellations_other": [
+                {
+                    "id": 10,
+                    "name": "Empty constellation",
+                    "description": ""
+                },
+                {
+                    "id": 2,
+                    "name": "Parasite",
+                    "description": "A second constellation."
+                },
+                {
+                    "id": 5,
+                    "name": "User recommendation",
+                    "description": "A constellation with a user recommendation"
+                }
+            ],
+            "recommendations": []
+        },
+        "is_an_event": false,
+        "url_override": ""
+    },
+    "data": {
+        "lens_reader": {
+            "mac_address": "00:00:00:00:00:00",
+            "reader_ip": "192.168.1.108",
+            "reader_model": "Postman",
+            "reader_name": "Simon"
+        }
+    }
+}

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -347,15 +347,15 @@ def test_send_tap_or_requeue_success_leds():
         tap_manager.last_id = '123456789'
         tap_manager.tap_on()
         assert tap_manager.queue.qsize() == 1
-        assert tap_manager.leds.blocked_by == 'tap'
+        assert not tap_manager.leds.blocked_by
 
         # send the tap
         return_code = tap_manager.send_tap_or_requeue()
         assert tap_manager.queue.qsize() == 0
         assert return_code == 0
-        assert tap_manager.last_id_failed is not None
+        assert tap_manager.last_id_failed is None
         assert not tap_manager.last_id_failed
-        assert fake_leds_success.call_count == 0
+        assert fake_leds_success.call_count == 1
 
         # simulate removing the lens
         tap_manager.tap_off()
@@ -371,7 +371,7 @@ def test_send_tap_or_requeue_success_leds():
         tap_manager.last_id = '123456789'
         tap_manager.tap_on()
         assert tap_manager.queue.qsize() == 1
-        assert tap_manager.leds.blocked_by == 'tap'
+        assert not tap_manager.leds.blocked_by
 
         # simulate removing the lens
         tap_manager.tap_off()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -83,9 +83,9 @@ def mocked_requests_post(*args, **kwargs):
     response = MockResponse('["No lens matching that uid could be found."]', 400)
 
     if 'maker-moment' in kwargs['url']:
-        response = MockResponse('{"response": "200"}', 200)
+        response = MockResponse(file_to_string_strip_new_lines('data/tap.json'), 200)
     elif 'xos' in kwargs['url']:
-        response = MockResponse('{"response": "201"}', 201)
+        response = MockResponse(file_to_string_strip_new_lines('data/tap.json'), 201)
     elif '500' in kwargs['url']:
         response = MockResponse('{"response": "502"}', 502)
 


### PR DESCRIPTION
Resolves #64

Allow the onboarding lens readers to show XOS tap LED responses that flash for 2 seconds, even when the Lens is still on the lens reader.

### Acceptance Criteria
- [x] Failed Lens tap - make the LEDs flash purple for 2 seconds (~3 times)
- [x] Success Lens tap - make the LEDs fade blue
- [x] Make both of these happen even if the Lens is held on the reader

### Relevant design files
* None

### Testing instructions
1. Move your Lens Reader to [e__tap-reader-pi-4](https://dashboard.balena-cloud.com/apps/1509309/devices)
2. Push this repo to make sure it's running the correct code: `balena push e__tap-reader-pi-4`
3. Set an environment variable for your device: `ONBOARDING_LEDS_API` to `http://192.168.1.116:5000/api/trigger` substituting your developer laptop's IP address
4. Tap your good Lens and hold it on the reader, note that the XOS response LEDs light up a blue colour
5. Tap your bad Lens and hold it on the reader, note that the XOS response LEDs flash a purple colour 3 times
6. Repeat the above two steps by tapping the Lens and removing it quickly, note the behaviour is the same
7. Remove the `ONBOARDING_LEDS_API` environment variable
8. Tap your good Lens and hold it on the reader, note that you don't see an extra LED response from XOS
9. Tap your bad Lens and hold it on the reader, note that you don't see a purple LED response until after you remove your Lens
10. Repeat the above two steps by tapping the Lens and removing it quickly, note the behaviour is the same
11. Also worth noting that I've stopped the spammy logging of the entire XOS Tap response in favour of this short one line: `XOS Tap created: 430, Lens: xp679t, Collectible: 1`

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
- ~[ ] Deployment / migration instruction have been updated if required~
