### PR TITLE
#66 Handle bad JSON data and non-XOS-Tap data from Tap responses

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -364,11 +364,14 @@ class TapManager:
             response = requests.post(url=TARGET_TAPS_ENDPOINT, json=tap, headers=headers, timeout=5)
             self.post_to_sentry = True
             if response.status_code in TAP_SUCCESS_RESPONSE_CODES:
-                data = response.json()
-                log(
-                    f'XOS Tap created: {data["id"]}, Lens: {data["lens_short_code"]}, '
-                    f'Collectible: {data["collectible"]["id"]}'
-                )
+                try:
+                    data = response.json()
+                    log(
+                        f'XOS Tap created: {data["id"]}, Lens: {data["lens_short_code"]}, '
+                        f'Collectible: {data["collectible"]["id"]}'
+                    )
+                except (json.decoder.JSONDecodeError, KeyError):
+                    log(response.text)
                 self.last_id_failed = False
 
                 if not self.leds.blocked_by and ONBOARDING_LEDS_API:


### PR DESCRIPTION
Resolves #66

Rather than crashing, handle bad JSON data and non-XOS-Tap data when attempting to parse a Tap response.

### Acceptance Criteria
- [x] Handle `JSONDecodeError` when bad data is returned from Maker Moments
- [x] If response doesn't include Tap data, print the raw response text

### Relevant design files
* None

### Testing instructions
1. Add your test Lens Reader to [e__tap-reader-pi-4](https://dashboard.balena-cloud.com/apps/1509309/devices)
2. Tap the Lens Reader and see it responds to XOS Taps
3. Set the Lens Reader to point to: http://192.168.2.2:5000/api/
4. Run the Flask server code below with: `export FLASK_APP=server.py` and `flask run --host=0.0.0.0`
5. Tap the Lens Reader and see that it handles the invalid JSON response and the Tap is saved successfully
6. Change the `server.py` response to: `{"ok": "true"}` and see that this response is handled too and the Tap is saved

```python
# server.py
from flask import Flask, Response, request
app = Flask(__name__)

@app.route('/')
def home():
    return trigger()

@app.route('/api/trigger', methods=['GET', 'POST'])
def trigger():
    print(request.get_json())
    return {"ok": True}

@app.route('/api/taps/', methods=['POST'])
def taps():
    print(request.get_json())
    return Response('{"ok" = "true"}', status=201, mimetype='application/json')
```

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
~- [ ] Deployment / migration instruction have been updated if required~
