### PR TITLE
#68 Re-queue Taps when a 5xx XOS response is received

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -404,7 +404,12 @@ class TapManager:
                 self.leds.failed()
                 self.leds.blocked_by = None
                 self.last_id_failed = None
-            sentry_sdk.capture_message(response.text)
+            if self.post_to_sentry:
+                sentry_sdk.capture_message(response.text)
+                self.post_to_sentry = False
+            self.queue.put((tap['tap_datetime'], tap))
+            log('Waiting for %s seconds to retry' % TAP_SEND_RETRY_SECS)
+            sleep(TAP_SEND_RETRY_SECS)
             return 1
 
         except (


### PR DESCRIPTION
Resolves #68

Re-queue Taps for 502/503 responses from XOS so that we don't lose any visitor Taps in the gallery when XOS infrastructure fails.

### Acceptance Criteria
- [x] Re-queue [502](https://sentry.io/organizations/ACMI/issues/2307620764/?project=1523556&query=is%3Aunresolved)/[503](https://sentry.io/organizations/ACMI/issues/2339679184/?project=1523556&query=is%3Aunresolved) Tap responses from XOS
- [x] Investigate if we're handling [ReadTimeout](https://sentry.io/organizations/ACMI/issues/2307843030/?project=1523556&query=is%3Aunresolved) errors (are they the same as [Timeout](https://github.com/ACMILabs/lens-reader/blob/main/src/runner.py#L412) errors)? No they're different, but catching a `Timeout` also catches `ReadTimeout`: https://2.python-requests.org/en/master/api/#exceptions

### Relevant design files
* None

### Testing instructions
1. Add your test Lens Reader to [e__tap-reader-pi-4](https://dashboard.balena-cloud.com/apps/1509309/devices)
2. Tap the Lens Reader and see it responds to XOS Taps
3. Set the Lens Reader to point to: http://<YOUR_LAPTOP_IP>:5000/api/
4. Run the Flask server code below with: `export FLASK_APP=server.py` and `flask run --host=0.0.0.0`
5. Tap the Lens Reader and see that it re-queues the Tap
6. Change the `server.py` status to: `201`, restart it, and see that the Lens Reader stops trying to re-send the Tap

```python
# server.py
from flask import Flask, Response, request
app = Flask(__name__)

@app.route('/')
def home():
    return trigger()

@app.route('/api/trigger', methods=['GET', 'POST'])
def trigger():
    print(request.get_json())
    return {"ok": True}

@app.route('/api/taps/', methods=['POST'])
def taps():
    print(request.get_json())
    return Response('{"ok": false}', status=502, mimetype='application/json')
```

### DoD
For requester to complete:
- [ ] All acceptance criteria are met
- [ ] New logic has been documented
- [ ] New logic has appropriate unit tests
- [ ] Changelog has been updated if necessary
- [ ] Deployment / migration instruction have been updated if required
