### PR TITLE
#70 Add Taps API to Lens Readers for maker moments

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -12,4 +12,4 @@ services:
     volumes:
       - ../:/code
     ports:
-     - 8081:8081
+     - 8082:8082

--- a/src/runner.py
+++ b/src/runner.py
@@ -508,18 +508,18 @@ class TapManager:
         Read the lines from the C interface and processes taps.
         """
         shell = True
-        popen = subprocess.Popen(CMD, cwd=FOLDER, shell=shell, stdout=subprocess.PIPE)
-        byte_string_re = r'([0-9a-fA-F]{2}:?)+'
+        with subprocess.Popen(CMD, cwd=FOLDER, shell=shell, stdout=subprocess.PIPE) as popen:
+            byte_string_re = r'([0-9a-fA-F]{2}:?)+'
 
-        while True:
-            # wait for the next line from the C interface
-            # (if there are no NFCs there will be no lines)
-            line = popen.stdout.readline().decode('utf-8')
+            while True:
+                # wait for the next line from the C interface
+                # (if there are no NFCs there will be no lines)
+                line = popen.stdout.readline().decode('utf-8')
 
-            # see if it is a tag read
-            if re.match(byte_string_re, line):
-                # We have an ID.
-                self.read_line(line)
+                # see if it is a tag read
+                if re.match(byte_string_re, line):
+                    # We have an ID.
+                    self.read_line(line)
 
 
 @app.route('/api/taps/', methods=['POST'])

--- a/src/runner.py
+++ b/src/runner.py
@@ -528,26 +528,18 @@ class TapManager:
 @app.route('/api/taps/', methods=['POST'])
 def taps_endpoint():
     """
-    Endpoint to accept Lens Taps which are then forwarded on to XOS.
+    Endpoint to accept Lens Taps which are then forwarded on to XOS via the tap queue.
 
-    A successful XOS response will return {"success": true}, 201
-
-    If XOS returns a failure code in XOS_FAILED_RESPONSE_CODES
-    the Tap will NOT be re-queued, and {"success": false}, 400 returned.
-
-    If XOS returns a failure code NOT in XOS_FAILED_RESPONSE_CODES
-    the Tap will be re-queued, and {"success": false}, 400 returned.
-
-    :param data: Tap data as JSON.
-    :type data: json
+    :param request_data: Tap data as JSON.
+    :type request_data: json
     :return: Success is set True unless the request_data is invalid
     """
     try:
         request_data = dict(request.get_json())
         tap_manager.queue.put((request_data['tap_datetime'], request_data, XOS_TAPS_ENDPOINT))
-        return json.dumps({"success": True}), 201
+        return json.dumps({'success': True}), 201
     except KeyError:
-        return json.dumps({"success": False, "error": "Did you include Tap data?"}), 400
+        return json.dumps({'success': False, 'error': 'Did you include Tap data?'}), 400
 
 
 @app.route('/api/lights/', methods=['POST'])

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import requests
 
 import src.runner
-from src.runner import LEDControllerThread, TARGET_TAPS_ENDPOINT, TapManager
+from src.runner import LEDControllerThread, TapManager
 from src.utils import env_to_tuple, get_ip_address
 
 src.runner.TAP_SEND_RETRY_SECS = 0.1
@@ -293,9 +293,9 @@ def test_send_tap_or_requeue_failure():
 
 
 @patch('requests.post', MagicMock(side_effect=mocked_requests_post))
-def test_send_tap_or_requeue_failure_unexpected_errors():
+def test_send_tap_or_requeue_failure_unexpected_errors_before_tap_off():
     """
-    Test send_tap_or_requeue handles unexpected (non-400) error responses from XOS.
+    Test send_tap_or_requeue handles unexpected (non-400) error responses from XOS before tap off.
     Test that the failed LEDs method is called as expected.
     """
     # XOS failed tap arrives before tap off
@@ -335,6 +335,13 @@ def test_send_tap_or_requeue_failure_unexpected_errors():
 
         src.runner.TARGET_TAPS_ENDPOINT = 'http://localhost:8000/api/taps/'
 
+
+@patch('requests.post', MagicMock(side_effect=mocked_requests_post))
+def test_send_tap_or_requeue_failure_unexpected_errors_after_tap_off():
+    """
+    Test send_tap_or_requeue handles unexpected (non-400) error responses from XOS after tap off.
+    Test that the failed LEDs method is called as expected.
+    """
     # XOS failed tap arrives after tap off
     tap_manager = TapManager()
     assert tap_manager.queue.empty()


### PR DESCRIPTION
Resolves #70

As a maker moment creator I want to be able to send Taps to a Lens Reader so I don't have to handle errors/re-queueing.

### Acceptance Criteria
- [x] Add `/api/taps/` to Lens Readers
- [x] Allow XOS Tap responses not in `XOS_FAILED_RESPONSE_CODES` to be re-queued

### Relevant design files
* None

### Testing instructions
1. Add your Lens Reader to: [e__tap-reader-pi-4](https://dashboard.balena-cloud.com/apps/1509309/summary)
1. Set `TARGET_API_ENDPOINT` to `http://YOUR_IP:5000/api/maker-moment/`
1. Set `XOS_TAPS_ENDPOINT` to `http://YOUR_IP:8000/api/taps/`
1. Run the fake maker moment Flask server below
1. Tap a good Lens and note that the Maker Moment tap is created successfully in XOS
1. Tap a bad Lens and note that the error LEDs flash
1. Stop the Flask server, Tap a good lens and see that the Maker Moment tap is queued and retries until you restart the Flask server.
1. Note that the Tap is created once you restart the Flask server
1. Stop XOS and note that a Tap is queued successfully
1. Restart XOS and see that the Tap is automatically created

### Flask server

```Python
import requests
import time
from flask import Flask, Response, request
app = Flask(__name__)

@app.route('/api/maker-moment/taps/', methods=['POST'])
def maker_moment_taps():
    data = request.get_json()
    data.pop('label')
    data['maker_moment'] = 2
    data['experience_id'] = 'some-experience-id'
    print(f'Posting to Lens Reader: {data}')
    time.sleep(1)
    response = requests.post(url='http://LENS_READER_IP:8082/api/taps/', json=data)
    print(f'Lens reader response: {response}')
    return Response('{"success": true, "maker_moment": 2, "experience_id": "some-experience-id"}', status=201, mimetype='application/json')
```

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
~- [ ] Changelog has been updated if necessary~
~- [ ] Deployment / migration instruction have been updated if required~
