### PR TITLE
#74 Ignore UIDs 8 characters or shorter

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -510,9 +510,7 @@ class TapManager:
                 self.tap_on()
             self._reset_tap_off_timer()
         else:
-            message = f'Ignoring {len(lens_id)} character UID: {lens_id}'
-            log(message)
-            sentry_sdk.capture_message(message)
+            log(f'Ignoring {len(lens_id)} character UID: {lens_id}')
 
     def process_taps(self):
         """

--- a/src/runner.py
+++ b/src/runner.py
@@ -470,8 +470,8 @@ class TapManager:
             self.last_id = None
             self.last_id_failed = None
             self.leds.blocked_by = None
-        elif self.leds.blocked_by == 'remote':
-            # if blocked by a remote LEDs command, leave LEDs alone, and only reset
+        elif self.leds.blocked_by == 'remote' or self.leds.blocked_by == 'xos':
+            # if blocked by another LED command, leave LEDs alone, and only reset
             # last lens id so we can still receive new tap on events
             self.last_id = None
         elif ONBOARDING_LEDS_API:

--- a/src/runner.py
+++ b/src/runner.py
@@ -442,7 +442,7 @@ class TapManager:
     def tap_on(self):
         log(' Tap On: ', self.last_id)
         # turn leds on only if not being used
-        if not self.leds.blocked_by:
+        if not self.leds.blocked_by and len(self.last_id) > 8:
             tap = self.create_tap(self.last_id)
             self.queue.put((tap['tap_datetime'], tap, TARGET_TAPS_ENDPOINT, AUTH_TOKEN))
             if not ONBOARDING_LEDS_API:

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -172,8 +172,7 @@ def test_tap_on_queues_taps():
     assert api_key == 'api-key'
 
 
-@patch('sentry_sdk.capture_message', side_effect=MagicMock())
-def test_tap_on_doesnt_queue_phone_taps(capture_message):
+def test_tap_on_doesnt_queue_phone_taps():
     """
     Test that a tap_on doesn't enqueue a phone tap (8 character UID)
     """
@@ -184,13 +183,11 @@ def test_tap_on_doesnt_queue_phone_taps(capture_message):
     uid = '04:04:A5:2C:F2'
     tap_manager.read_line(uid)
     assert tap_manager.queue.qsize() == 0
-    assert capture_message.call_count == 1
 
     # lens UID as a byte string
     uid = '04:04:A5:2C:F2:2A:5E:80'
     tap_manager.read_line(uid)
     assert tap_manager.queue.qsize() == 1
-    assert capture_message.call_count == 1
 
 
 @patch('requests.post', MagicMock(side_effect=mocked_requests_post))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -172,6 +172,26 @@ def test_tap_on_queues_taps():
     assert api_key == 'api-key'
 
 
+def test_tap_on_doesnt_queue_phone_taps():
+    """
+    Test that a tap_on doesn't enqueue a phone tap (8 character UID)
+    """
+    tap_manager = TapManager()
+    src.runner.AUTH_TOKEN = 'api-key'
+    assert tap_manager.queue.empty()
+
+    # a phone tap UID which is 8 characters
+    tap_manager.last_id = '12345678'
+    tap_manager.tap_on()
+    assert tap_manager.queue.qsize() == 0
+    tap_manager.tap_off()
+
+    # add a tap to the queue
+    tap_manager.last_id = '123456789'
+    tap_manager.tap_on()
+    assert tap_manager.queue.qsize() == 1
+
+
 @patch('requests.post', MagicMock(side_effect=mocked_requests_post))
 def test_send_tap_or_requeue():
     """


### PR DESCRIPTION
Resolves #74

Ignore NFC phone taps which present as 8 character UIDs. Our Lenses are 14 characters long.

### Acceptance Criteria
- [x] Ignore NFC phone taps (8 character UIDs)

### Relevant design files
* None

### Testing instructions
1. Add your Lens Reader to: [e__tap-reader-pi-4](https://dashboard.balena-cloud.com/apps/1509309/summary)
1. Tap on your Lens Reader with your phone and see that the taps are logged, but not sent to XOS
1. Tap a good Lens and see that the tap is sent to XOS
1. Tap a bad Lens and see that you get the purple LED response

### DoD
For requester to complete:
- [x] All acceptance criteria are met
- [x] New logic has been documented
- [x] New logic has appropriate unit tests
~- [ ] Changelog has been updated if necessary~
~- [ ] Deployment / migration instruction have been updated if required~
